### PR TITLE
Add "contains" methods for STL containers

### DIFF
--- a/include/sst/cpputils.h
+++ b/include/sst/cpputils.h
@@ -6,5 +6,5 @@
  * by choosing the files below if you prefer
  */
 
+#include "sst/cpputils/algorithms.h"
 #include "sst/cpputils/iterators.h"
-

--- a/include/sst/cpputils/algorithms.h
+++ b/include/sst/cpputils/algorithms.h
@@ -15,20 +15,20 @@ namespace cpputils
 /**
  * Wrapper of std::find to check if a container contains a value
  */
-template <class InputIt, class T>
-constexpr bool contains(InputIt begin, InputIt end, const T &value)
+template <class ContainerType, class T>
+constexpr bool contains(const ContainerType& container, const T &value)
 {
-    return std::find(begin, end, value) != end;
+    return std::find(container.begin(), container.end(), value) != container.end();
 }
 
 /**
  * Wrapper of std::find_if to check if a container contains a value for which the predicate returns
  * true
  */
-template <class InputIt, class UnaryPredicate>
-constexpr bool contains_if(InputIt begin, InputIt end, UnaryPredicate q)
+template <class ContainerType, class UnaryPredicate>
+constexpr bool contains_if(const ContainerType& container, UnaryPredicate q)
 {
-    return std::find_if(begin, end, q) != end;
+    return std::find_if(container.begin(), container.end(), q) != container.end();
 }
 
 } // namespace cpputils

--- a/include/sst/cpputils/algorithms.h
+++ b/include/sst/cpputils/algorithms.h
@@ -1,0 +1,37 @@
+/*
+ * algorithms: A set of utilities for working with containers
+ */
+
+#ifndef SST_CPPUTILS_ALGORITHMS_H
+#define SST_CPPUTILS_ALGORITHMS_H
+
+#include <algorithm>
+
+namespace sst
+{
+namespace cpputils
+{
+
+/**
+ * Wrapper of std::find to check if a container contains a value
+ */
+template <class InputIt, class T>
+constexpr bool contains(InputIt begin, InputIt end, const T &value)
+{
+    return std::find(begin, end, value) != end;
+}
+
+/**
+ * Wrapper of std::find_if to check if a container contains a value for which the predicate returns
+ * true
+ */
+template <class InputIt, class UnaryPredicate>
+constexpr bool contains_if(InputIt begin, InputIt end, UnaryPredicate q)
+{
+    return std::find_if(begin, end, q) != end;
+}
+
+} // namespace cpputils
+} // namespace sst
+
+#endif // SST_CPPUTILS_ALGORITHMS_H

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -160,6 +160,56 @@ TEST_CASE("Zip")
     }
 }
 
+TEST_CASE("Contains")
+{
+    SECTION("Simple Vector")
+    {
+        std::vector<int> v{1, 3, 5, 7};
+
+        REQUIRE(sst::cpputils::contains(v, 3));
+        REQUIRE(! sst::cpputils::contains(v, 2));
+
+        auto isEven = [] (const auto& x) { return x % 2 == 0; };
+        auto isOdd = [] (const auto& x) { return x % 2 == 1; };
+        REQUIRE(sst::cpputils::contains_if(v, isOdd));
+        REQUIRE(! sst::cpputils::contains_if(v, isEven));
+    }
+
+    SECTION("Some other types")
+    {
+        std::string abcs = "abcdefg";
+        REQUIRE(sst::cpputils::contains(abcs, 'e'));
+        REQUIRE(! sst::cpputils::contains(abcs, 'y'));
+
+        std::array<char, 4> abcarr{'d', 'e', 'f', 'g'};
+        REQUIRE(sst::cpputils::contains(abcarr, 'e'));
+        REQUIRE(! sst::cpputils::contains(abcarr, 'y'));
+    }
+
+    SECTION("Empty Containers")
+    {
+        auto empty = [](const auto &v, auto dummyVal) {
+            REQUIRE(! sst::cpputils::contains(v, dummyVal));
+        };
+        empty(std::vector<int>(), 0);
+        empty(std::string(), char());
+        empty(std::array<int, 0>(), 0);
+    }
+
+    SECTION("Map Contains")
+    {
+        std::map<std::string, std::string> m;
+        m["hi"] = "there";
+        m["zoo"] = "keeper";
+
+        REQUIRE(sst::cpputils::contains_if(m, [] (const auto& pair) { return pair.first == "hi"; }));
+        REQUIRE(! sst::cpputils::contains_if(m, [] (const auto& pair) { return pair.first == "not_a_key"; }));
+
+        REQUIRE(sst::cpputils::contains_if(m, [] (const auto& pair) { return pair.second == "keeper"; }));
+        REQUIRE(! sst::cpputils::contains_if(m, [] (const auto& pair) { return pair.second == "not_a_value"; }));
+    }
+}
+
 int main(int argc, char **argv)
 {
     int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
`std::map` has a `contains()` method starting in C++20, but most other containers don't have anything like that. The closest you can get is:
```cpp
if (std::find(container.begin(), container.end(), value) != container.end())
    ...
```

Hopefully these methods will make that kind of thing a little more readable!