### PR TITLE
Add `nodal_erase_if` algorithm

### DIFF
--- a/include/sst/cpputils/algorithms.h
+++ b/include/sst/cpputils/algorithms.h
@@ -13,22 +13,37 @@ namespace cpputils
 {
 
 /**
- * Wrapper of std::find to check if a container contains a value
+ * Wrapper of std::find to check if a container contains a value.
  */
 template <class ContainerType, class T>
-constexpr bool contains(const ContainerType& container, const T &value)
+constexpr bool contains(const ContainerType &container, const T &value)
 {
     return std::find(container.begin(), container.end(), value) != container.end();
 }
 
 /**
  * Wrapper of std::find_if to check if a container contains a value for which the predicate returns
- * true
+ * true.
  */
 template <class ContainerType, class UnaryPredicate>
-constexpr bool contains_if(const ContainerType& container, UnaryPredicate q)
+constexpr bool contains_if(const ContainerType &container, UnaryPredicate q)
 {
     return std::find_if(container.begin(), container.end(), q) != container.end();
+}
+
+/**
+ * Similar to std::erase_if, but much easier to use for node-based containers (e.g. std::map).
+ */
+template <class ContainerType, class UnaryPredicate>
+constexpr void nodal_erase_if(ContainerType &container, UnaryPredicate q)
+{
+    for (auto it = container.begin(); it != container.end();)
+    {
+        if (q(*it))
+            it = container.erase(it);
+        else
+            ++it;
+    }
 }
 
 } // namespace cpputils


### PR DESCRIPTION
`std::remove_if` doesn't work with containers like `std::map<int, Type>` when `Type` has a user-declared move constructor, and from what I've read it has similar issues with other node-based containers. I kept using the same pattern to do that sort of operation, so I figured I'd put it into an algorithm here.