### PR TITLE
Add array constructors with bound indices

### DIFF
--- a/include/sst/cpputils/constructors.h
+++ b/include/sst/cpputils/constructors.h
@@ -18,13 +18,57 @@ std::array<T, sizeof...(Is)> make_array_helper(std::index_sequence<Is...>, Args 
 {
     return {(static_cast<void>(Is), T{std::forward<Args>(args)...})...};
 }
+
+template <typename T, size_t... Is, typename... Args>
+std::array<T, sizeof...(Is)> make_array_helper_last_index(std::index_sequence<Is...>,
+                                                          Args &&...args)
+{
+    return {(static_cast<void>(Is), T{std::forward<Args>(args)..., Is})...};
+}
+
+template <typename T, size_t... Is, typename... Args>
+std::array<T, sizeof...(Is)> make_array_helper_first_index(std::index_sequence<Is...>,
+                                                           Args &&...args)
+{
+    return {(static_cast<void>(Is), T{Is, std::forward<Args>(args)...})...};
+}
 } // namespace detail
 
+/*
+ * Construct an n element array for a type which is non-default constructable. So
+ *
+ * struct Foo { Foo(int a, const std::string &b) {} };
+ * std::array<Foo,18> foo;
+ *
+ * has a problem when constructing. You can do
+ *
+ * std::array<Foo, 18> foo{sst::cpputils::make_array<Foo, 18>(174, "test")};
+ *
+ * and get expected result. We also have two variations which can bind the first
+ * or last constructor element to th eindex so
+ *
+ * std::array<Foo, 18> foo{sst::cpputils::make_array_bind_first_idnex<Foo, 18>("test")};
+ *
+ * will construct with the a bound to 0, 1, 2, ...
+ */
+template <typename T, size_t N, typename... Args> std::array<T, N> make_array(Args &&...args)
+{
+    return detail::make_array_helper<T>(std::make_index_sequence<N>{}, std::forward<Args>(args)...);
+}
+
 template <typename T, size_t N, typename... Args>
-std::array<T, N> make_array(Args&&... args) {
-    return detail::make_array_helper<T>(std::make_index_sequence<N>{},
-                              std::forward<Args>(args)...);
+std::array<T, N> make_array_bind_last_index(Args &&...args)
+{
+    return detail::make_array_helper_last_index<T>(std::make_index_sequence<N>{},
+                                                   std::forward<Args>(args)...);
 }
+
+template <typename T, size_t N, typename... Args>
+std::array<T, N> make_array_bind_first_index(Args &&...args)
+{
+    return detail::make_array_helper_first_index<T>(std::make_index_sequence<N>{},
+                                                    std::forward<Args>(args)...);
 }
+} // namespace sst::cpputils
 
 #endif // CONDUIT_CONSTRUCTORS_H

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -597,17 +597,47 @@ TEST_CASE("LRU")
 
 TEST_CASE("Array CTor")
 {
-   struct NeedsArgs {
-     int a, b;
-     NeedsArgs(int aa, int bb) : a(aa), b(bb) {}
-     int val() { return a * 1000 + b; }
-   };
-   
-   std::array<NeedsArgs, 20> arr{sst::cpputils::make_array<NeedsArgs, 20>(17, 42)};
-   for (auto &a : arr)
-   {
-      REQUIRE(a.val() == 17042);
-   }
+    struct NeedsArgs
+    {
+        int a, b;
+        NeedsArgs(int aa, int bb) : a(aa), b(bb) {}
+        int val() const { return a * 1000 + b; }
+    };
+
+    std::array<NeedsArgs, 20> arr{sst::cpputils::make_array<NeedsArgs, 20>(17, 42)};
+    for (const auto &a : arr)
+    {
+        REQUIRE(a.val() == 17042);
+    }
+}
+
+TEST_CASE("Array Indexed CTor")
+{
+    struct NeedsArgs
+    {
+        int a, b;
+        NeedsArgs(int aa, int bb) : a(aa), b(bb) {}
+        int val() const { return a * 1000 + b; }
+    };
+
+    SECTION("Last Index")
+    {
+        std::array<NeedsArgs, 20> arr{sst::cpputils::make_array_bind_last_index<NeedsArgs, 20>(17)};
+        for (const auto &[idx, a] : sst::cpputils::enumerate(arr))
+        {
+            REQUIRE(a.val() == 17000 + idx);
+        }
+    }
+
+    SECTION("First Index")
+    {
+        std::array<NeedsArgs, 20> arr{
+            sst::cpputils::make_array_bind_first_index<NeedsArgs, 20>(23)};
+        for (const auto &[idx, a] : sst::cpputils::enumerate(arr))
+        {
+            REQUIRE(a.val() == 1000 * idx + 23);
+        }
+    }
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The arracy construct shortcut was handy but sometime syou want to parameterize the constructor, so add a version which sets an index.