### PR TITLE
Add RTSan and Small Hash; Update Copyright Year

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -20,12 +20,12 @@ jobs:
             name: mac
             testExe: build/sst-cpputils-tests
 
-          - os: windows-latest
+          - os: windows-2022
             name: win msvc
             testExe: build/Release/sst-cpputils-tests.exe
             cmake-args: -A x64
 
-          - os: windows-latest
+          - os: windows-2022
             name: win clangcl
             testExe: build/Release/sst-cpputils-tests.exe
             cmake-args: -A x64 -T ClangCL  -G"Visual Studio 17 2022"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (SST_CPPUTILS_BUILD_TESTS)
     target_link_libraries(sst-cpputils-tests PRIVATE ${PROJECT_NAME})
     target_include_directories(sst-cpputils-tests PRIVATE libs/catch2)
     target_sources(sst-cpputils-tests PRIVATE
-            tests/tests.cpp tests/scope_guard_tests.cpp)
+            tests/tests.cpp tests/scope_guard_tests.cpp tests/small_hash_map_tests.cpp)
 
     add_custom_command(TARGET sst-cpputils-tests
             POST_BUILD

--- a/include/sst/cpputils.h
+++ b/include/sst/cpputils.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/active_set_overlay.h
+++ b/include/sst/cpputils/active_set_overlay.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/algorithms.h
+++ b/include/sst/cpputils/algorithms.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/aligned_allocator.h
+++ b/include/sst/cpputils/aligned_allocator.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2025, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/bindings.h
+++ b/include/sst/cpputils/bindings.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/constructors.h
+++ b/include/sst/cpputils/constructors.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/dyn_array.h
+++ b/include/sst/cpputils/dyn_array.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2025, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/fixed_allocater.h
+++ b/include/sst/cpputils/fixed_allocater.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/iterators.h
+++ b/include/sst/cpputils/iterators.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/lru_cache.h
+++ b/include/sst/cpputils/lru_cache.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/ring_buffer.h
+++ b/include/sst/cpputils/ring_buffer.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/rtsan_support.h
+++ b/include/sst/cpputils/rtsan_support.h
@@ -1,0 +1,81 @@
+/*
+ * sst-cpputils - an open source library of things we needed in C++
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful for writing C++-17 code
+ *
+ * Copyright 2022-2026, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-cpputils is released under the MIT License found in the "LICENSE"
+ * file in the root of this repository
+ *
+ * All source in sst-cpputils available at
+ * https://github.com/surge-synthesizer/sst-cpputils
+ */
+
+/*
+ * Helpers for clang's RealtimeSanitizer (-fsanitize=realtime).
+ *
+ * - SST_CPPUTILS_HAS_RTSAN     1 when compiling a realtime-sanitizer build, else undefined/0.
+ * - SST_CPPUTILS_NONBLOCKING  tags a function as a realtime context ([[clang::nonblocking]]);
+ *                             expands to nothing on any other compiler.
+ * - SST_CPPUTILS_RTSAN_DISABLE / SST_CPPUTILS_RTSAN_ENABLE
+ *                             declare a scoped RAII guard that suspends / re-asserts rtsan
+ *                             checking for the enclosing scope. ENABLE is only meaningful nested
+ *                             inside a disabled (or nonblocking) region. Both are no-ops without
+ *                             rtsan.
+ *
+ * Everything here is a no-op unless a realtime-sanitizer build is detected, so the same source
+ * compiles and runs identically under any compiler.
+ */
+
+#ifndef INCLUDE_SST_CPPUTILS_RTSAN_SUPPORT_H
+#define INCLUDE_SST_CPPUTILS_RTSAN_SUPPORT_H
+
+#if defined(__has_feature)
+#if __has_feature(realtime_sanitizer)
+#define SST_CPPUTILS_HAS_RTSAN 1
+#endif
+#endif
+
+#if SST_CPPUTILS_HAS_RTSAN
+
+// These live in the rtsan runtime. Newer llvm declares them in <sanitizer/rtsan_interface.h>,
+// but llvm 20 does not, so declare them ourselves (a matching redeclaration is harmless).
+extern "C" void __rtsan_realtime_enter(void);
+extern "C" void __rtsan_realtime_exit(void);
+extern "C" void __rtsan_disable(void);
+extern "C" void __rtsan_enable(void);
+
+namespace sst::cpputils::rtsan
+{
+struct ScopedDisabler // suspend rtsan checks for this scope, re-enable on exit
+{
+    ScopedDisabler() { __rtsan_disable(); }
+    ~ScopedDisabler() { __rtsan_enable(); }
+    ScopedDisabler(const ScopedDisabler &) = delete;
+    ScopedDisabler &operator=(const ScopedDisabler &) = delete;
+};
+struct ScopedEnabler // re-assert rtsan checks for this scope (use nested in a disabled region)
+{
+    ScopedEnabler() { __rtsan_enable(); }
+    ~ScopedEnabler() { __rtsan_disable(); }
+    ScopedEnabler(const ScopedEnabler &) = delete;
+    ScopedEnabler &operator=(const ScopedEnabler &) = delete;
+};
+} // namespace sst::cpputils::rtsan
+
+#define SST_CPPUTILS_NONBLOCKING [[clang::nonblocking]]
+#define SST_CPPUTILS_RTSAN_DISABLE ::sst::cpputils::rtsan::ScopedDisabler sstCpputilsRtsanDisabler_
+#define SST_CPPUTILS_RTSAN_ENABLE ::sst::cpputils::rtsan::ScopedEnabler sstCpputilsRtsanEnabler_
+
+#else
+
+#define SST_CPPUTILS_NONBLOCKING
+#define SST_CPPUTILS_RTSAN_DISABLE (void)0
+#define SST_CPPUTILS_RTSAN_ENABLE (void)0
+
+#endif
+
+#endif // INCLUDE_SST_CPPUTILS_RTSAN_SUPPORT_H

--- a/include/sst/cpputils/scope_guard.h
+++ b/include/sst/cpputils/scope_guard.h
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/include/sst/cpputils/small_hash_map.h
+++ b/include/sst/cpputils/small_hash_map.h
@@ -1,0 +1,494 @@
+/*
+ * sst-cpputils - an open source library of things we needed in C++
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful for writing C++-17 code
+ *
+ * Copyright 2022-2026, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-cpputils is released under the MIT License found in the "LICENSE"
+ * file in the root of this repository
+ *
+ * All source in sst-cpputils available at
+ * https://github.com/surge-synthesizer/sst-cpputils
+ */
+
+#ifndef INCLUDE_SST_CPPUTILS_SMALL_HASH_MAP_H
+#define INCLUDE_SST_CPPUTILS_SMALL_HASH_MAP_H
+
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <functional>
+#include <type_traits>
+#include <cassert>
+
+namespace sst::cpputils
+{
+
+/*
+ * Small-buffer-optimized open-addressing hash containers for the realtime path.
+ *
+ * They hold up to InlineCap elements without touching the heap; past that they spill
+ * to one heap allocation and *retain* that capacity across clear(), so a given instance
+ * allocates at most once (on first exceeding its inline buffer) and is then allocation
+ * free in steady state. Linear probing with power-of-two buckets; erase uses backward
+ * shift deletion so there are no tombstones. The key must be hashable and equality
+ * comparable. There is no per-element shrink.
+ */
+
+namespace smallhash_detail
+{
+constexpr size_t nextPow2(size_t n)
+{
+    size_t c{1};
+    while (c < n)
+        c <<= 1;
+    return c;
+}
+// buckets sized so InlineCap elements stay under a 0.75 load factor
+constexpr size_t bucketsFor(size_t inlineCap)
+{
+    return nextPow2((inlineCap == 0 ? 1 : inlineCap) * 4 / 3 + 1);
+}
+} // namespace smallhash_detail
+
+template <typename K, typename V, size_t InlineCap, typename Hash = std::hash<K>> class SmallHashMap
+{
+    static constexpr size_t kBuckets = smallhash_detail::bucketsFor(InlineCap);
+
+    struct Slot
+    {
+        std::pair<K, V> kv{};
+        bool used{false};
+    };
+
+    Slot inlineSlots_[kBuckets];
+    Slot *slots_{inlineSlots_};
+    size_t cap_{kBuckets};
+    size_t size_{0};
+
+    bool spilled() const { return slots_ != inlineSlots_; }
+
+    // is k cyclically within the open-left/closed-right interval (lo, hi]?
+    static bool inCyclicRange(size_t k, size_t lo, size_t hi)
+    {
+        return (lo < hi) ? (lo < k && k <= hi) : (lo < k || k <= hi);
+    }
+
+    void rawInsert(K k, V v) // no load-factor check; used while rehashing
+    {
+        size_t mask = cap_ - 1;
+        size_t i = Hash{}(k)&mask;
+        while (slots_[i].used)
+            i = (i + 1) & mask;
+        slots_[i].kv = {std::move(k), std::move(v)};
+        slots_[i].used = true;
+        ++size_;
+    }
+
+    void grow(size_t want)
+    {
+        size_t newCap = smallhash_detail::nextPow2(want < kBuckets ? kBuckets : want);
+        Slot *old = slots_;
+        size_t oldCap = cap_;
+        slots_ = new Slot[newCap]; // the rare, retained allocation
+        cap_ = newCap;
+        size_ = 0;
+        for (size_t i = 0; i < oldCap; ++i)
+            if (old[i].used)
+                rawInsert(std::move(old[i].kv.first), std::move(old[i].kv.second));
+        if (old != inlineSlots_)
+            delete[] old;
+    }
+
+    void releaseHeap()
+    {
+        if (spilled())
+            delete[] slots_;
+        slots_ = inlineSlots_;
+        cap_ = kBuckets;
+        size_ = 0;
+        for (auto &s : inlineSlots_)
+            s.used = false;
+    }
+
+    void copyFrom(const SmallHashMap &o)
+    {
+        if (o.spilled())
+        {
+            slots_ = new Slot[o.cap_];
+            cap_ = o.cap_;
+        }
+        else
+        {
+            slots_ = inlineSlots_;
+            cap_ = kBuckets;
+        }
+        for (size_t i = 0; i < cap_; ++i)
+            slots_[i] = o.slots_[i];
+        size_ = o.size_;
+    }
+
+    void moveFrom(SmallHashMap &&o)
+    {
+        if (o.spilled())
+        {
+            slots_ = o.slots_; // steal the heap buffer
+            cap_ = o.cap_;
+            size_ = o.size_;
+            o.slots_ = o.inlineSlots_; // can't steal an inline pointer; leave o empty-inline
+            o.cap_ = kBuckets;
+            o.size_ = 0;
+            for (auto &s : o.inlineSlots_)
+                s.used = false;
+        }
+        else
+        {
+            slots_ = inlineSlots_;
+            cap_ = kBuckets;
+            for (size_t i = 0; i < kBuckets; ++i)
+                inlineSlots_[i] = std::move(o.inlineSlots_[i]);
+            size_ = o.size_;
+        }
+    }
+
+    void eraseIndex(size_t i)
+    {
+        const size_t mask = cap_ - 1;
+        size_t j = i;
+        while (true)
+        {
+            j = (j + 1) & mask;
+            if (!slots_[j].used)
+                break;
+            size_t k = Hash{}(slots_[j].kv.first) & mask;
+            if (!inCyclicRange(k, i, j)) // slots_[j] may fill the hole at i
+            {
+                slots_[i].kv = std::move(slots_[j].kv);
+                slots_[i].used = true;
+                i = j;
+            }
+        }
+        slots_[i].used = false;
+        --size_;
+    }
+
+  public:
+    SmallHashMap() = default;
+    ~SmallHashMap()
+    {
+        if (spilled())
+            delete[] slots_;
+    }
+    SmallHashMap(const SmallHashMap &o) { copyFrom(o); }
+    SmallHashMap(SmallHashMap &&o) noexcept { moveFrom(std::move(o)); }
+    SmallHashMap &operator=(const SmallHashMap &o)
+    {
+        if (this != &o)
+        {
+            releaseHeap();
+            copyFrom(o);
+        }
+        return *this;
+    }
+    SmallHashMap &operator=(SmallHashMap &&o) noexcept
+    {
+        if (this != &o)
+        {
+            releaseHeap();
+            moveFrom(std::move(o));
+        }
+        return *this;
+    }
+
+    bool empty() const { return size_ == 0; }
+    size_t size() const { return size_; }
+    // Current bucket count. Starts at the inline capacity and only exceeds it once the container
+    // has spilled to the heap, so capacity() growing past its initial value proves a spill.
+    size_t capacity() const { return cap_; }
+
+    template <bool Const> struct iter_t
+    {
+        using slot_t = std::conditional_t<Const, const Slot, Slot>;
+        using pair_t = std::conditional_t<Const, const std::pair<K, V>, std::pair<K, V>>;
+        slot_t *p, *e;
+        void skip()
+        {
+            while (p != e && !p->used)
+                ++p;
+        }
+        iter_t &operator++()
+        {
+            ++p;
+            skip();
+            return *this;
+        }
+        pair_t &operator*() const { return p->kv; }
+        pair_t *operator->() const { return &p->kv; }
+        bool operator==(const iter_t &o) const { return p == o.p; }
+        bool operator!=(const iter_t &o) const { return p != o.p; }
+    };
+    using iterator = iter_t<false>;
+    using const_iterator = iter_t<true>;
+
+    iterator begin()
+    {
+        iterator it{slots_, slots_ + cap_};
+        it.skip();
+        return it;
+    }
+    iterator end() { return {slots_ + cap_, slots_ + cap_}; }
+    const_iterator begin() const
+    {
+        const_iterator it{slots_, slots_ + cap_};
+        it.skip();
+        return it;
+    }
+    const_iterator end() const { return {slots_ + cap_, slots_ + cap_}; }
+
+    iterator find(const K &k)
+    {
+        size_t mask = cap_ - 1;
+        for (size_t i = Hash{}(k)&mask; slots_[i].used; i = (i + 1) & mask)
+            if (slots_[i].kv.first == k)
+                return {slots_ + i, slots_ + cap_};
+        return end();
+    }
+
+    V &operator[](const K &k)
+    {
+        if (4 * (size_ + 1) > 3 * cap_)
+            grow(cap_ * 2);
+        size_t mask = cap_ - 1;
+        size_t i = Hash{}(k)&mask;
+        while (slots_[i].used)
+        {
+            if (slots_[i].kv.first == k)
+                return slots_[i].kv.second;
+            i = (i + 1) & mask;
+        }
+        slots_[i].kv = {k, V{}};
+        slots_[i].used = true;
+        ++size_;
+        return slots_[i].kv.second;
+    }
+
+    V &at(const K &k)
+    {
+        auto it = find(k);
+        assert(it != end());
+        return it->second;
+    }
+
+    void erase(iterator it)
+    {
+        if (it != end())
+            eraseIndex(static_cast<size_t>(it.p - slots_));
+    }
+    void erase(const K &k) { erase(find(k)); }
+
+    void clear()
+    {
+        for (size_t i = 0; i < cap_; ++i)
+            slots_[i].used = false;
+        size_ = 0;
+    }
+};
+
+template <typename K, size_t InlineCap, typename Hash = std::hash<K>> class SmallHashSet
+{
+    static constexpr size_t kBuckets = smallhash_detail::bucketsFor(InlineCap);
+
+    struct Slot
+    {
+        K key{};
+        bool used{false};
+    };
+
+    Slot inlineSlots_[kBuckets];
+    Slot *slots_{inlineSlots_};
+    size_t cap_{kBuckets};
+    size_t size_{0};
+
+    bool spilled() const { return slots_ != inlineSlots_; }
+
+    void rawInsert(K k)
+    {
+        size_t mask = cap_ - 1;
+        size_t i = Hash{}(k)&mask;
+        while (slots_[i].used)
+            i = (i + 1) & mask;
+        slots_[i].key = std::move(k);
+        slots_[i].used = true;
+        ++size_;
+    }
+
+    void grow(size_t want)
+    {
+        size_t newCap = smallhash_detail::nextPow2(want < kBuckets ? kBuckets : want);
+        Slot *old = slots_;
+        size_t oldCap = cap_;
+        slots_ = new Slot[newCap];
+        cap_ = newCap;
+        size_ = 0;
+        for (size_t i = 0; i < oldCap; ++i)
+            if (old[i].used)
+                rawInsert(std::move(old[i].key));
+        if (old != inlineSlots_)
+            delete[] old;
+    }
+
+    void releaseHeap()
+    {
+        if (spilled())
+            delete[] slots_;
+        slots_ = inlineSlots_;
+        cap_ = kBuckets;
+        size_ = 0;
+        for (auto &s : inlineSlots_)
+            s.used = false;
+    }
+
+    void copyFrom(const SmallHashSet &o)
+    {
+        if (o.spilled())
+        {
+            slots_ = new Slot[o.cap_];
+            cap_ = o.cap_;
+        }
+        else
+        {
+            slots_ = inlineSlots_;
+            cap_ = kBuckets;
+        }
+        for (size_t i = 0; i < cap_; ++i)
+            slots_[i] = o.slots_[i];
+        size_ = o.size_;
+    }
+
+    void moveFrom(SmallHashSet &&o)
+    {
+        if (o.spilled())
+        {
+            slots_ = o.slots_;
+            cap_ = o.cap_;
+            size_ = o.size_;
+            o.slots_ = o.inlineSlots_;
+            o.cap_ = kBuckets;
+            o.size_ = 0;
+            for (auto &s : o.inlineSlots_)
+                s.used = false;
+        }
+        else
+        {
+            slots_ = inlineSlots_;
+            cap_ = kBuckets;
+            for (size_t i = 0; i < kBuckets; ++i)
+                inlineSlots_[i] = std::move(o.inlineSlots_[i]);
+            size_ = o.size_;
+        }
+    }
+
+  public:
+    SmallHashSet() = default;
+    ~SmallHashSet()
+    {
+        if (spilled())
+            delete[] slots_;
+    }
+    SmallHashSet(const SmallHashSet &o) { copyFrom(o); }
+    SmallHashSet(SmallHashSet &&o) noexcept { moveFrom(std::move(o)); }
+    SmallHashSet &operator=(const SmallHashSet &o)
+    {
+        if (this != &o)
+        {
+            releaseHeap();
+            copyFrom(o);
+        }
+        return *this;
+    }
+    SmallHashSet &operator=(SmallHashSet &&o) noexcept
+    {
+        if (this != &o)
+        {
+            releaseHeap();
+            moveFrom(std::move(o));
+        }
+        return *this;
+    }
+
+    bool empty() const { return size_ == 0; }
+    size_t size() const { return size_; }
+    // Current bucket count. Starts at the inline capacity and only exceeds it once the container
+    // has spilled to the heap, so capacity() growing past its initial value proves a spill.
+    size_t capacity() const { return cap_; }
+
+    bool contains(const K &k) const
+    {
+        size_t mask = cap_ - 1;
+        for (size_t i = Hash{}(k)&mask; slots_[i].used; i = (i + 1) & mask)
+            if (slots_[i].key == k)
+                return true;
+        return false;
+    }
+
+    void insert(const K &k)
+    {
+        if (contains(k))
+            return;
+        if (4 * (size_ + 1) > 3 * cap_)
+            grow(cap_ * 2);
+        rawInsert(k);
+    }
+
+    void clear()
+    {
+        for (size_t i = 0; i < cap_; ++i)
+            slots_[i].used = false;
+        size_ = 0;
+    }
+
+    template <bool Const> struct iter_t
+    {
+        using slot_t = std::conditional_t<Const, const Slot, Slot>;
+        using key_t = std::conditional_t<Const, const K, K>;
+        slot_t *p, *e;
+        void skip()
+        {
+            while (p != e && !p->used)
+                ++p;
+        }
+        iter_t &operator++()
+        {
+            ++p;
+            skip();
+            return *this;
+        }
+        key_t &operator*() const { return p->key; }
+        bool operator==(const iter_t &o) const { return p == o.p; }
+        bool operator!=(const iter_t &o) const { return p != o.p; }
+    };
+    using iterator = iter_t<false>;
+    using const_iterator = iter_t<true>;
+
+    iterator begin()
+    {
+        iterator it{slots_, slots_ + cap_};
+        it.skip();
+        return it;
+    }
+    iterator end() { return {slots_ + cap_, slots_ + cap_}; }
+    const_iterator begin() const
+    {
+        const_iterator it{slots_, slots_ + cap_};
+        it.skip();
+        return it;
+    }
+    const_iterator end() const { return {slots_ + cap_, slots_ + cap_}; }
+};
+
+} // namespace sst::cpputils
+
+#endif // INCLUDE_SST_CPPUTILS_SMALL_HASH_MAP_H

--- a/scripts/fix_file_comments.pl
+++ b/scripts/fix_file_comments.pl
@@ -27,7 +27,7 @@ sub findfiles {
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"

--- a/tests/scope_guard_tests.cpp
+++ b/tests/scope_guard_tests.cpp
@@ -1,7 +1,17 @@
-/* This is taken from scope_guard by ricab, original URL:
- * https://ricab.github.io/scope_guard/
+/*
+ * sst-cpputils - an open source library of things we needed in C++
+ * built by Surge Synth Team.
  *
- * Originally released to the public domain.
+ * Provides a collection of tools useful for writing C++-17 code
+ *
+ * Copyright 2022-2026, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-cpputils is released under the MIT License found in the "LICENSE"
+ * file in the root of this repository
+ *
+ * All source in sst-cpputils available at
+ * https://github.com/surge-synthesizer/sst-cpputils
  */
 
 #include "sst/cpputils/scope_guard.h"

--- a/tests/small_hash_map_tests.cpp
+++ b/tests/small_hash_map_tests.cpp
@@ -1,0 +1,227 @@
+/*
+ * sst-cpputils - an open source library of things we needed in C++
+ * built by Surge Synth Team.
+ *
+ * Provides a collection of tools useful for writing C++-17 code
+ *
+ * Copyright 2022-2026, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-cpputils is released under the MIT License found in the "LICENSE"
+ * file in the root of this repository
+ *
+ * All source in sst-cpputils available at
+ * https://github.com/surge-synthesizer/sst-cpputils
+ */
+
+#include "sst/cpputils/small_hash_map.h"
+
+#include "catch2.hpp"
+
+#include <set>
+#include <utility>
+
+using sst::cpputils::SmallHashMap;
+using sst::cpputils::SmallHashSet;
+
+TEST_CASE("SmallHashMap basic operations")
+{
+    SmallHashMap<int, int, 8> m;
+    REQUIRE(m.empty());
+    REQUIRE(m.size() == 0);
+
+    m[1] = 10;
+    m[2] = 20;
+    m[3] = 30;
+    REQUIRE_FALSE(m.empty());
+    REQUIRE(m.size() == 3);
+    REQUIRE(m[1] == 10);
+    REQUIRE(m[2] == 20);
+    REQUIRE(m.at(3) == 30);
+
+    // operator[] on an existing key returns the slot and updates in place
+    m[2] = 99;
+    REQUIRE(m.size() == 3);
+    REQUIRE(m[2] == 99);
+
+    // find hits and misses
+    REQUIRE(m.find(2) != m.end());
+    REQUIRE(m.find(2)->second == 99);
+    REQUIRE(m.find(12345) == m.end());
+
+    m.clear();
+    REQUIRE(m.empty());
+    REQUIRE(m.size() == 0);
+    REQUIRE(m.find(1) == m.end());
+}
+
+TEST_CASE("SmallHashMap iteration visits every entry exactly once")
+{
+    SmallHashMap<int, int, 8> m;
+    for (int i = 0; i < 6; ++i)
+        m[i] = i * 100;
+
+    std::set<int> seen;
+    int count = 0;
+    for (auto &[k, v] : m)
+    {
+        REQUIRE(v == k * 100);
+        seen.insert(k);
+        ++count;
+    }
+    REQUIRE(count == 6);
+    REQUIRE(seen.size() == 6);
+}
+
+TEST_CASE("SmallHashMap erase by key and iterator")
+{
+    SmallHashMap<int, int, 8> m;
+    for (int i = 0; i < 6; ++i)
+        m[i] = i;
+
+    m.erase(2);
+    REQUIRE(m.size() == 5);
+    REQUIRE(m.find(2) == m.end());
+    for (int i : {0, 1, 3, 4, 5})
+    {
+        REQUIRE(m.find(i) != m.end());
+        REQUIRE(m.find(i)->second == i);
+    }
+
+    auto it = m.find(4);
+    REQUIRE(it != m.end());
+    m.erase(it);
+    REQUIRE(m.size() == 4);
+    REQUIRE(m.find(4) == m.end());
+
+    // erasing an absent key is a no-op
+    m.erase(999);
+    REQUIRE(m.size() == 4);
+}
+
+// Hash everything to one bucket so every key shares a probe chain. This is the worst case for
+// linear probing and exercises the backward-shift deletion that keeps the table tombstone-free.
+struct AllCollide
+{
+    size_t operator()(int) const { return 0; }
+};
+
+TEST_CASE("SmallHashMap backward-shift deletion under total collision")
+{
+    SmallHashMap<int, int, 16, AllCollide> m;
+    for (int i = 0; i < 10; ++i)
+        m[i] = i * 7;
+    REQUIRE(m.size() == 10);
+
+    // Remove from the middle of the chain; every survivor must still be reachable.
+    m.erase(5);
+    REQUIRE(m.find(5) == m.end());
+    for (int i = 0; i < 10; ++i)
+        if (i != 5)
+        {
+            REQUIRE(m.find(i) != m.end());
+            REQUIRE(m.find(i)->second == i * 7);
+        }
+
+    // Remove the head and tail of the chain and another interior element.
+    for (int i : {0, 9, 3})
+        m.erase(i);
+    REQUIRE(m.size() == 6);
+    for (int i : {1, 2, 4, 6, 7, 8})
+    {
+        REQUIRE(m.find(i) != m.end());
+        REQUIRE(m.find(i)->second == i * 7);
+    }
+}
+
+TEST_CASE("SmallHashMap spills to the heap past its inline capacity")
+{
+    SmallHashMap<int, int, 2> m; // deliberately tiny inline buffer
+    const auto inlineBuckets = m.capacity();
+    REQUIRE(inlineBuckets >= 2);
+
+    // A handful of entries stay inline: capacity must not change (no heap allocation).
+    m[0] = 0;
+    REQUIRE(m.capacity() == inlineBuckets);
+
+    // Push well past the inline buffer. This forces at least one grow()+rehash to the heap.
+    constexpr int N = 200;
+    for (int i = 0; i < N; ++i)
+        m[i] = i * 3;
+
+    REQUIRE(m.size() == N);
+    REQUIRE(m.capacity() > inlineBuckets); // capacity grew beyond inline => it spilled to the heap
+
+    // Every entry survived the grow/rehash with the right value.
+    for (int i = 0; i < N; ++i)
+    {
+        REQUIRE(m.find(i) != m.end());
+        REQUIRE(m.at(i) == i * 3);
+    }
+
+    // clear() keeps the grown capacity (so steady-state reuse never re-allocates) and the map
+    // remains fully usable afterward.
+    const auto grown = m.capacity();
+    m.clear();
+    REQUIRE(m.empty());
+    REQUIRE(m.capacity() == grown);
+    m[42] = 7;
+    REQUIRE(m.size() == 1);
+    REQUIRE(m[42] == 7);
+}
+
+TEST_CASE("SmallHashMap copy and move with a spilled buffer")
+{
+    SmallHashMap<int, int, 2> src;
+    for (int i = 0; i < 50; ++i)
+        src[i] = i + 1; // forces a spill
+    REQUIRE(src.size() == 50);
+    REQUIRE(src.capacity() > 4);
+
+    // A copy is a fully independent deep copy.
+    auto cp = src;
+    REQUIRE(cp.size() == 50);
+    cp[0] = 999;
+    REQUIRE(cp[0] == 999);
+    REQUIRE(src[0] == 1); // source untouched
+    for (int i = 1; i < 50; ++i)
+        REQUIRE(cp.at(i) == i + 1);
+
+    // A move carries the contents across.
+    auto mv = std::move(src);
+    REQUIRE(mv.size() == 50);
+    for (int i = 1; i < 50; ++i)
+        REQUIRE(mv.at(i) == i + 1);
+}
+
+TEST_CASE("SmallHashSet basic operations, dedup, and spill")
+{
+    SmallHashSet<int, 4> s;
+    REQUIRE(s.empty());
+
+    s.insert(10);
+    s.insert(20);
+    s.insert(10); // duplicate is ignored
+    REQUIRE(s.size() == 2);
+    REQUIRE(s.contains(10));
+    REQUIRE(s.contains(20));
+    REQUIRE_FALSE(s.contains(30));
+
+    // Spill: 10 and 20 are within 0..99 so the final count is exactly 100.
+    const auto inlineBuckets = s.capacity();
+    for (int i = 0; i < 100; ++i)
+        s.insert(i);
+    REQUIRE(s.size() == 100);
+    REQUIRE(s.capacity() > inlineBuckets); // spilled to the heap
+    for (int i = 0; i < 100; ++i)
+        REQUIRE(s.contains(i));
+
+    std::set<int> seen;
+    for (auto k : s)
+        seen.insert(k);
+    REQUIRE(seen.size() == 100);
+
+    s.clear();
+    REQUIRE(s.empty());
+    REQUIRE_FALSE(s.contains(5));
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,7 +4,7 @@
  *
  * Provides a collection of tools useful for writing C++-17 code
  *
- * Copyright 2022-2024, various authors, as described in the GitHub
+ * Copyright 2022-2026, various authors, as described in the GitHub
  * transaction log.
  *
  * sst-cpputils is released under the MIT License found in the "LICENSE"


### PR DESCRIPTION
1. add rtsan headers which make it easier to use rtsan with a set of block binding macros etc
2. Add a smallhash / smallset class which is basically a hash and set on a fixed size array with grow-over in case capacity is exceeded but very useful for the case where basically it isn't
3. Update copyright header to be consistent and span to 2026

Assisted-By: Claude Opus 4.8

Claude was especially useful in generatino of the smallhash/smallset classes which are basic data structures with tests, but where basically the entire class is machine generated